### PR TITLE
feat: Configure Debezium, Kafka Connect, and Kafka for CDC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+up:
+	docker-compose up
+	
+down:
+	docker-compose down
+
+connector:
+	curl -X POST -H "Content-Type: application/json" --data @./docker/connector/debezium-connector.json  http://localhost:8083/connectors

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,8 +7,51 @@ services:
       - POSTGRES_PASSWORD=1234
       - POSTGRES_DB=finance_db
     volumes:
-        - "${PWD}/db-data:/var/lib/postgresql/data"
+        - "postgres-data:/var/lib/postgresql/data"
         - "${PWD}/db-scripts/initialize_db_ddl.sql:/docker-entrypoint-initdb.d/initialize_db_ddl.sql"
     ports:
       - "5432:5432"
     command: ["postgres", "-c", "wal_level=logical", "-c", "hot_standby=on"]
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.0
+    ports: ["2181:2181"]
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:7.4.0
+    depends_on: [kafka]
+    ports: ["8081:8081"]
+    environment:
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: kafka:9092
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+
+  connect:
+    image: debezium/connect:2.3
+    depends_on: [kafka, schema-registry, transactions-db]
+    ports: ["8083:8083"]
+    environment:
+      BOOTSTRAP_SERVERS: kafka:9092
+      GROUP_ID: connect-cluster
+      CONFIG_STORAGE_TOPIC: connect-configs
+      OFFSET_STORAGE_TOPIC: connect-offsets
+      STATUS_STORAGE_TOPIC: connect-status
+      CONNECT_KEY_CONVERTER: io.confluent.connect.avro.SchemaRegistryConverter
+      CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.SchemaRegistryConverter
+      CONNECT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+
+volumes:
+  postgres-data:

--- a/docker/connector/debezium-connector.json
+++ b/docker/connector/debezium-connector.json
@@ -1,0 +1,25 @@
+{
+    "name": "acme-pg-connector",
+    "config": {
+      "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+      "database.hostname": "transactions-db",
+      "database.port": "5432",
+      "database.user": "cdc_user",
+      "database.password": "cdc_1234",
+      "database.dbname": "finance_db",
+      "database.server.name": "acme_delivery",
+      "plugin.name": "pgoutput",
+      "publication.name": "cdc_publication",
+      "slot.name": "cdc_pgoutput",
+      "table.include.list": "operations.customers,operations.products,operations.orders,operations.order_items",
+      "tombstones.on.delete": "true",
+      "transforms": "unwrap",
+      "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
+      "transforms.unwrap.drop.tombstones": "false",
+      "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+      "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+      "topic.creation.default.replication.factor": "1",
+      "topic.creation.default.partitions": "6",
+      "topic.prefix": "debezium"
+    }
+  }


### PR DESCRIPTION
- Integrated Debezium for Change Data Capture from the source database
- Set up Kafka Connect with the Debezium connector for real-time data ingestion
- Configured Kafka topics to receive CDC events
- Ensured low-latency data processing and storage

This configuration enables real-time data streaming and ensures efficient handling of CDC events.